### PR TITLE
SER-1355: Quickstart should have a serial.ComponentInstances.create()

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -3,6 +3,12 @@ import serialmfg as serial
 serial.set_station_id('YOUR_STATION_ID')
 serial.set_api_key('YOUR_API_KEY')
 
+# Creating a component instance
+my_component_instance = serial.ComponentInstances.create(
+    identifier='ABC-1234', 
+    component_name='YOUR_COMPONENT_NAME'
+)
+
 # Creating a process entry
 my_process_entry = serial.ProcessEntries.create(
     process_id='YOUR_PROCESS_ID', 
@@ -10,7 +16,7 @@ my_process_entry = serial.ProcessEntries.create(
 )
 
 # Adding data to a process entry
-my_process_entry.add_text(dataset_name="Foo", value="bar")
+my_process_entry.add_text(dataset_name="Foo", value="Bar")
 my_process_entry.add_number(dataset_name="Pi Approx", value=3.141, lsl=3.1, usl=3.2)
 
 # Submitting a process entry


### PR DESCRIPTION
My philosophy is that quickstarts should be runnable (with the exception of replacing string placeholders like "YOUR_API_KEY"). Our current quickstarts is not runnable because it doesn't create a component instance before making the process entry.